### PR TITLE
ZSTD error code on ZSTD.Error where possible

### DIFF
--- a/Sources/ZSTD/InternalTypes/CompressContext.swift
+++ b/Sources/ZSTD/InternalTypes/CompressContext.swift
@@ -20,11 +20,11 @@ final class CompressContext {
 extension CompressContext {
     func set(level: ZSTD.Level) throws {
         let result: Int = ZSTD_CCtx_setParameter(pointer, ZSTD_c_compressionLevel, level.rawValue)
-        if ZSTD.Error.isError(result) { throw ZSTD.Error.setParameter(description: ZSTD.Error.errorName(code: result)) }
+        if ZSTD.Error.isError(result) { throw ZSTD.Error.setParameter(code: result) }
     }
 
     func load(dictionary: ZSTD.Dictionary) throws {
         let result: Int = try ZSTD_CCtx_loadDictionary(pointer, dictionary.pointer, dictionary.size)
-        if ZSTD.Error.isError(result) { throw ZSTD.Error.loadDictionary(description: ZSTD.Error.errorName(code: result)) }
+        if ZSTD.Error.isError(result) { throw ZSTD.Error.loadDictionary(code: result) }
     }
 }

--- a/Sources/ZSTD/InternalTypes/DecompressContext.swift
+++ b/Sources/ZSTD/InternalTypes/DecompressContext.swift
@@ -23,13 +23,13 @@ extension DecompressContext {
             switch parameter {
             case .windowLogMax(let value):
                 let result: Int = ZSTD_DCtx_setParameter(pointer, ZSTD_d_windowLogMax, value)
-                if ZSTD.Error.isError(result) { throw ZSTD.Error.setParameter(description: ZSTD.Error.errorName(code: result)) }
+                if ZSTD.Error.isError(result) { throw ZSTD.Error.setParameter(code: result) }
             }
         }
     }
 
     func load(dictionary: ZSTD.Dictionary) throws {
         let result = try ZSTD_DCtx_loadDictionary(pointer, dictionary.pointer, dictionary.size)
-        if ZSTD.Error.isError(result) { throw ZSTD.Error.loadDictionary(description: ZSTD.Error.errorName(code: result)) }
+        if ZSTD.Error.isError(result) { throw ZSTD.Error.loadDictionary(code: result) }
     }
 }

--- a/Sources/ZSTD/Types/ZSTD.Error.swift
+++ b/Sources/ZSTD/Types/ZSTD.Error.swift
@@ -9,17 +9,17 @@ public extension ZSTD {
     enum Error: Swift.Error {
         case encoderCreate
         case decoderCreate
-        case setParameter(description: String?)
-        case compress
-        case decompress
+        case setParameter(code: Int)
+        case compress(code: Int = 1)
+        case decompress(code: Int = 1)
         case invalidData
         case write(expect: Int, written: Int)
         case dictionaryData
-        case loadDictionary(description: String?)
+        case loadDictionary(code: Int)
     }
 }
 
-extension ZSTD.Error {
+public extension ZSTD.Error {
     static func isError(_ code: Int) -> Bool {
         ZSTD_isError(code) != 0
     }


### PR DESCRIPTION
I'm just informing the ZSTD raw error where it is available, so we can get a more precise error. Then we can just use the now public `ZSTD.Error.errorName` to get a more precise description for all errors that get an error code.